### PR TITLE
Fix dependency install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Redcloud uses `PyYAML` to print the list of available templates. It's installed 
 If not, simply run:
 ```bash
 # Use pip3 if default python version is 2.x
-> pip install -r requirements
+> pip install -r requirements.txt
 ```
 
 The Redcloud menu offers 3 different deployment methods:


### PR DESCRIPTION
## Goal of this PR

This PR fixes #4 by adding the file extension in the documentation for installing Redcloud's requirements.

## How to test it

- `pip uninstall PyYAML`
- Copy paste the instructions from the `README.md` file and execute the command
- Run `pip list | grep YAML`, your output should be similar to the following

![Screenshot 2019-03-17 at 16 55 15](https://user-images.githubusercontent.com/6976628/54493931-7a623080-48d5-11e9-8e12-8bd60e345990.png)
