### PR TITLE
fixed uname to run on remote ssh host

### DIFF
--- a/redcloud.py
+++ b/redcloud.py
@@ -66,10 +66,10 @@ def is_tool(name):
 
 
 
-def get_unames():
+def get_unames(prefix = ""):
     # $(uname -s)-$(uname -m)
-    uname_s = run_cmd_output("uname -s")
-    uname_m = run_cmd_output("uname -m")
+    uname_s = run_cmd_output(prefix + "uname -s")
+    uname_m = run_cmd_output(prefix + "uname -m")
     final_cmd = DOCKER_COMPOSE_INSTALL.format(u_s=uname_s, u_m=uname_m)
     print(final_cmd)
     return final_cmd
@@ -124,7 +124,7 @@ def install_docker_compose(prefix = ""):
     Runs the command to install docker-compose. Can run with the SSH prefix to install remotly
     Keep both seperated for later debugging
     '''
-    cmd = get_unames()
+    cmd = get_unames(prefix)
     if len(prefix) != 0:
         output = run_cmd_output(prefix + cmd)
         output += run_cmd_output(prefix + DOCKER_COMPOSE_INSTALL2)


### PR DESCRIPTION
During installation on a remote host via ssh, docker-compose gets installed. 
To determine the correct platform to download and install docker-compose, `uname` is called, but on the local system. If the architecture is different to the remote host's architecture, an incorrect binary version of docker-compose is installed. 
This fix makes sure, uname is called on the remote host before installing docker-compose. 